### PR TITLE
Potential fix for code scanning alert no. 7: Uncontrolled data used in path expression

### DIFF
--- a/server.js
+++ b/server.js
@@ -247,8 +247,14 @@ app.post('/upload', validateContentType, async (req, res) => {
     // Geçici dosya kullanımı, büyük dosyaları belleğe yüklemeden işlemeyi sağlar
     if (uploadedFile.tempFilePath) {
       try {
-        fileBuffer = fs.readFileSync(uploadedFile.tempFilePath);
-        console.log('Dosya geçici dosyadan okundu:', uploadedFile.tempFilePath);
+        const safeRoot = path.resolve(__dirname, 'uploads');
+        const normalizedPath = path.resolve(uploadedFile.tempFilePath);
+        if (!normalizedPath.startsWith(safeRoot)) {
+          console.error('Geçersiz dosya yolu:', uploadedFile.tempFilePath);
+          return res.status(400).json({ error: 'Geçersiz dosya yolu' });
+        }
+        fileBuffer = fs.readFileSync(normalizedPath);
+        console.log('Dosya geçici dosyadan okundu:', normalizedPath);
       } catch (err) {
         console.error('Geçici dosya okuma hatası:', err);
         return res.status(400).json({ error: 'Dosya okunamadı' });


### PR DESCRIPTION
Potential fix for [https://github.com/umutcrs/fileup/security/code-scanning/7](https://github.com/umutcrs/fileup/security/code-scanning/7)

To fix the problem, we need to ensure that the file path derived from user input is validated and sanitized before being used. We can achieve this by normalizing the path using `path.resolve` and then checking that the normalized path is within a designated safe directory. This will prevent directory traversal attacks by ensuring that the file path does not escape the intended directory.

1. Normalize the file path using `path.resolve`.
2. Check that the normalized path starts with the root directory.
3. If the path is invalid, return an error response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
